### PR TITLE
fix newline escaping in events

### DIFF
--- a/events.go
+++ b/events.go
@@ -14,7 +14,7 @@ var eventKeys = []string{"date_happened", "hostname", "aggregation_key", "priori
 var eventMarkers = []rune{'d', 'h', 'k', 'p', 's', 't'}
 
 func escapeEvent(s string) string {
-	return strings.NewReplacer("\n", "\\\\n").Replace(s)
+	return strings.NewReplacer("\n", "\\n").Replace(s)
 }
 
 func removePipes(s string) string {

--- a/events_test.go
+++ b/events_test.go
@@ -50,7 +50,7 @@ func TestEvent(t *testing.T) {
 		return
 	}
 
-	err = g.Event("some\nother event", "some body", nil, nil)
+	err = g.Event("some\nother event", "some\nbody", nil, nil)
 
 	if err != nil {
 		t.Error(err.Error())
@@ -64,7 +64,7 @@ func TestEvent(t *testing.T) {
 		return
 	}
 
-	b := []byte("_e{18,9}:some\\\\nother event|some body")
+	b := []byte("_e{17,10}:some\\nother event|some\\nbody")
 
 	if !bytes.Equal(a, b) {
 		t.Error(noGo(a, b))

--- a/godspeed_test.go
+++ b/godspeed_test.go
@@ -16,7 +16,6 @@ const closedChan = "return channel (out) closed prematurely"
 
 func listener(l *net.UDPConn, ctrl chan int, c chan []byte) {
 	for {
-	NextListen:
 		select {
 		case _, ok := <-ctrl:
 			if !ok {
@@ -29,7 +28,7 @@ func listener(l *net.UDPConn, ctrl chan int, c chan []byte) {
 			_, err := l.Read(buffer)
 
 			if err != nil {
-				goto NextListen
+				continue
 			}
 
 			c <- bytes.Trim(buffer, "\x00")


### PR DESCRIPTION
There was a bug where an extra slash was being inserted when the newline was escaped. Due to what I can only imagine was a fluke, the test was written to expect the failing value.

While here, I also remove a goto statement that wasn't needed in the tests.
