### PR TITLE
improve emission of sampleRate

### DIFF
--- a/async_test.go
+++ b/async_test.go
@@ -228,7 +228,7 @@ func TestAsyncSend(t *testing.T) {
 		return
 	}
 
-	b := []byte("godspeed.test.stat:42|g|@0.990000|#test0,test1,test8,test9")
+	b := []byte("godspeed.test.stat:42|g|@0.99|#test0,test1,test8,test9")
 
 	if !bytes.Equal(a, b) {
 		t.Error(noGo(a, b))

--- a/stats.go
+++ b/stats.go
@@ -34,14 +34,15 @@ func (g *Godspeed) Send(stat, kind string, delta, sampleRate float64, tags []str
 		buffer.WriteString(fmt.Sprintf("%v.", g.Namespace))
 	}
 
-	deltaStr := strconv.FormatFloat(delta, 'f', -1, 64)
+	floatStr := strconv.FormatFloat(delta, 'f', -1, 64)
 
 	// write the name of the metric to the byte buffer as well as the metric itself
-	buffer.WriteString(fmt.Sprintf("%v:%v|%v", string(trimReserved(stat)), deltaStr, kind))
+	buffer.WriteString(fmt.Sprintf("%v:%v|%v", string(trimReserved(stat)), floatStr, kind))
 
 	// if the sample rate is less than 1 add it too
 	if sampleRate < 1 {
-		buffer.WriteString(fmt.Sprintf("|@%f", sampleRate))
+		floatStr = strconv.FormatFloat(sampleRate, 'f', -1, 64)
+		buffer.WriteString(fmt.Sprintf("|@%v", floatStr))
 	}
 
 	// add any provided tags to the metric

--- a/stats_test.go
+++ b/stats_test.go
@@ -143,7 +143,7 @@ func TestSend(t *testing.T) {
 		return
 	}
 
-	b = []byte("testing.metric:256.512|ms|@0.990000")
+	b = []byte("testing.metric:256.512|ms|@0.99")
 
 	if !bytes.Equal(a, b) {
 		t.Error(noGo(a, b))


### PR DESCRIPTION
By converting sampleRate to use FormatFloat, it only prints significant digits thus it may send less data over the wire as trailing zeros are discarded.

This was done for the metric delta awhile back, may do it here too.
