### PR TITLE
convert godspeed_test to use gocheck

### DIFF
--- a/godspeed_test.go
+++ b/godspeed_test.go
@@ -5,217 +5,128 @@
 package godspeed_test
 
 import (
-	"bytes"
 	"net"
-	"strings"
 	"testing"
 
 	"github.com/PagerDuty/godspeed"
 	"github.com/PagerDuty/godspeed/gspdtest"
+
+	// this is *C comes from
+	. "gopkg.in/check.v1"
 )
 
 const closedChan = "return channel (out) closed prematurely"
 
-func testBasicFunctionality(t *testing.T, g *godspeed.Godspeed, l *net.UDPConn, ctrl chan int, out chan []byte) {
-	err := g.Send("test.metric", "c", 1, 1, nil)
+func Test(t *testing.T) { TestingT(t) }
 
-	if err != nil {
-		// if the send failed there's no reason to continue the test
-		t.Error(err.Error())
-		return
-	}
-
-	a, ok := <-out
-
-	if !ok {
-		// error and return as there is no reason to run further tests
-		// they will most likely fail as this channel has been closed early
-		t.Error(closedChan)
-		return
-	}
-
-	b := []byte("test.metric:1|c")
-
-	if !bytes.Equal(a, b) {
-		t.Error(gspdtest.NoGo(a, b))
-	}
-
-	if len(g.Tags) != 0 {
-		t.Errorf("there are more than zero tags set: %v", strings.Join(g.Tags, ", "))
-	}
-
-	if len(g.Namespace) != 0 {
-		t.Errorf("a namespace has already been set: %v", g.Namespace)
-	}
+type TestSuite struct {
+	g *godspeed.Godspeed
+	l *net.UDPConn
+	c chan int
+	o chan []byte
 }
 
-func TestNew(t *testing.T) {
-	// define port for listener
-	const port uint16 = 8126
-	var g *godspeed.Godspeed
+var _ = Suite(&TestSuite{})
 
-	// build the listener and return the following:
-	// listener, control channel (close to stop), and the out (return) channel
-	l, ctrl, out := gspdtest.BuildListener(port)
+// func (t *TestSuite) SetUpSuite(c *C) {}
 
-	// defer cleaning up stuff
-	defer l.Close()
-	defer close(ctrl)
+// func (t *TestSuite) TearDownSuite(c *C) {}
 
-	// send the listener out to a goroutine
-	go gspdtest.Listener(l, ctrl, out)
+func (t *TestSuite) SetUpTest(c *C) {
+	gs, err := godspeed.NewDefault()
+	c.Assert(err, IsNil)
+	t.g = gs
 
+	t.l, t.c, t.o = gspdtest.BuildListener(8125)
+	go gspdtest.Listener(t.l, t.c, t.o)
+}
+
+func (t *TestSuite) TearDownTest(c *C) {
+	t.l.Close()
+	close(t.c)
+	t.g.Conn.Close()
+	// time.Sleep(time.Millisecond * 5)
+}
+
+func testBasicFunc(c *C, g *godspeed.Godspeed, l *net.UDPConn, ctrl chan int, out chan []byte) {
+	err := g.Send("test.metric", "c", 1, 1, nil)
+	c.Assert(err, IsNil)
+
+	a, ok := <-out
+	c.Assert(ok, Equals, true)
+
+	b := []byte("test.metric:1|c")
+	c.Check(string(a), Equals, string(b))
+	c.Check(len(g.Tags), Equals, 0)
+	c.Check(g.Namespace, Equals, "")
+}
+
+func (t *TestSuite) TestNew(c *C) {
 	// build Godspeed
-	g, err := gspdtest.BuildGodspeed(port, false)
+	var g *godspeed.Godspeed
+	g, err := godspeed.New("127.0.0.1", 8125, false)
+	c.Assert(err, IsNil)
 
-	if err != nil {
-		// we failed to get a Godspeed client
-		t.Error(err.Error())
-		return
-	}
-
-	// defer closing the client for Godspeed
 	defer g.Conn.Close()
 
 	// test defined basic functionality
-	testBasicFunctionality(t, g, l, ctrl, out)
+	testBasicFunc(c, g, t.l, t.c, t.o)
 }
 
-func TestNewDefault(t *testing.T) {
-	const port uint16 = 8125
+func (t *TestSuite) TestNewDefault(c *C) {
 	var g *godspeed.Godspeed
-
-	l, ctrl, out := gspdtest.BuildListener(port)
-
-	defer l.Close()
-	defer close(ctrl)
-
-	go gspdtest.Listener(l, ctrl, out)
-
 	g, err := godspeed.NewDefault()
-
-	if err != nil {
-		t.Errorf("unexpected error when building new Godspeed client: %v", err)
-		return
-	}
+	c.Assert(err, IsNil)
 
 	defer g.Conn.Close()
 
-	testBasicFunctionality(t, g, l, ctrl, out)
+	testBasicFunc(c, g, t.l, t.c, t.o)
 }
 
-func TestAddTag(t *testing.T) {
-	var g *godspeed.Godspeed
+func (t *TestSuite) TestAddTag(c *C) {
+	c.Assert(len(t.g.Tags), Equals, 0)
 
-	g, err := gspdtest.BuildGodspeed(godspeed.DefaultPort, false)
+	t.g.AddTag("test")
+	c.Assert(len(t.g.Tags), Equals, 1)
+	c.Check(t.g.Tags[0], Equals, "test")
 
-	if err != nil {
-		t.Error(err.Error())
-		return
-	}
+	t.g.AddTag("test2")
+	t.g.AddTag("test") // verify tags are de-duped
 
-	defer g.Conn.Close()
-
-	if len(g.Tags) != 0 {
-		t.Errorf("tags have already been set on the Godspeed instance: %v", strings.Join(g.Tags, ", "))
-		return
-	}
-
-	g.AddTag("test")
-
-	if len(g.Tags) != 1 || g.Tags[0] != "test" {
-		t.Errorf("something went wrong adding 'test' tag; current tags: %v", strings.Join(g.Tags, ", "))
-	}
-
-	g.AddTag("test2")
-	g.AddTag("test") // verify we de-dupe
-
-	if len(g.Tags) != 2 || g.Tags[0] != "test" || g.Tags[1] != "test2" {
-		t.Errorf("something went wrong adding 'test2' tag; current tags: %v", strings.Join(g.Tags, ", "))
-	}
+	c.Assert(len(t.g.Tags), Equals, 2)
+	c.Check(t.g.Tags[0], Equals, "test")
+	c.Check(t.g.Tags[1], Equals, "test2")
 }
 
-func TestAddTags(t *testing.T) {
-	var g *godspeed.Godspeed
-
-	g, err := gspdtest.BuildGodspeed(godspeed.DefaultPort, false)
-
-	if err != nil {
-		t.Error(err.Error())
-		return
-	}
-
-	defer g.Conn.Close()
-
-	// make sure no tags are set
-	if len(g.Tags) != 0 {
-		t.Errorf("tags have already been set on the Godspeed instance: %v", strings.Join(g.Tags, ", "))
-		return
-	}
+func (t *TestSuite) TestAddTags(c *C) {
+	c.Assert(len(t.g.Tags), Equals, 0)
 
 	tags := []string{"test1", "test2", "test1"}
 
-	//
-	// test that adding the first set of tags worked
-	//
-	g.AddTags(tags)
+	t.g.AddTags(tags)
+	c.Assert(len(t.g.Tags), Equals, 2)
 
-	//verify two tags
-	if len(g.Tags) != 2 {
-		t.Error("expected there to be two tags")
+	// match content
+	for i := range t.g.Tags {
+		c.Check(t.g.Tags[i], Equals, tags[i])
 	}
 
-	// match the two tags
-	for i, v := range g.Tags {
-		if v != tags[i] {
-			t.Errorf("expected %v to equal %v", v, tags[i])
-		}
-	}
-
-	// add some more tags
 	tags2 := []string{"test3", "test4", "test5", "test4"}
 	tags = append(tags, tags2...)
 
-	//
-	// test that appending the second set of tags works without overwriting the first
-	//
-	g.AddTags(tags2)
+	t.g.AddTags(tags2)
+	c.Assert(len(t.g.Tags), Equals, 5)
 
-	// expected tags
 	control := []string{"test1", "test2", "test3", "test4", "test5"}
 
-	// match length
-	if len(g.Tags) != 5 {
-		t.Error("expected there to be 5 tags")
-	}
-
 	// match content
-	for i, v := range g.Tags {
-		if v != control[i] {
-			t.Errorf("expected %v to equal %v", v, tags[i])
-		}
+	for i := range t.g.Tags {
+		c.Check(t.g.Tags[i], Equals, control[i])
 	}
 }
 
-func TestSetNamespace(t *testing.T) {
-	var g *godspeed.Godspeed
-
-	g, err := gspdtest.BuildGodspeed(godspeed.DefaultPort, false)
-
-	if err != nil {
-		t.Error(err.Error())
-		return
-	}
-
-	defer g.Conn.Close()
-
-	if len(g.Namespace) != 0 {
-		t.Errorf("namespace has already been set on the Godspeed instance: %v", g.Namespace)
-	}
-
-	g.SetNamespace("heckman")
-
-	if g.Namespace != "heckman" {
-		t.Errorf("failure while trying to set Namespace to 'heckman', is: %v", g.Namespace)
-	}
+func (t *TestSuite) TestSetNamespace(c *C) {
+	c.Check(t.g.Namespace, Equals, "")
+	t.g.SetNamespace("heckman")
+	c.Check(t.g.Namespace, Equals, "heckman")
 }


### PR DESCRIPTION
This converts the unit tests in `godspeed_test.go` to use gocheck. This makes the actual unit tests more DRY and readable.
