### PR TITLE
use an int instead of uint16 for the port number

### DIFF
--- a/async.go
+++ b/async.go
@@ -24,7 +24,7 @@ type AsyncGodspeed struct {
 // autoTruncate dictactes whether long stats emissions get auto-truncated or dropped. Unfortunately,
 // Events will always be dropped. If you need monitor your events, you can access the Godspeed instance
 // directly.
-func NewAsync(host string, port uint16, autoTruncate bool) (a *AsyncGodspeed, err error) {
+func NewAsync(host string, port int, autoTruncate bool) (a *AsyncGodspeed, err error) {
 	gs, err := New(host, port, autoTruncate)
 
 	if err != nil {

--- a/godspeed.go
+++ b/godspeed.go
@@ -21,7 +21,7 @@ const (
 	DefaultHost = "127.0.0.1"
 
 	// DefaultPort is 8125
-	DefaultPort uint16 = 8125
+	DefaultPort = 8125
 
 	// MaxBytes is the largest UDP datagram we will try to send
 	// this is 8192 bytes minus the size of a UDP header
@@ -51,11 +51,11 @@ type Godspeed struct {
 }
 
 // New returns a new instance of a Godspeed statsd client.
-// This method takes the host as a string, and port as a uint16.
+// This method takes the host as a string, and port as an int.
 // There is also the ability for autoTruncate. If your metric is longer than MaxBytes
 // autoTruncate can be used to truncate the message instead of erroring. This doesn't work
 // on events and will always return an error.
-func New(host string, port uint16, autoTruncate bool) (g *Godspeed, err error) {
+func New(host string, port int, autoTruncate bool) (g *Godspeed, err error) {
 	// build a new UDP dialer
 	c, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.ParseIP(host), Port: int(port)})
 

--- a/gspdtest/gspdtest.go
+++ b/gspdtest/gspdtest.go
@@ -32,7 +32,7 @@ func Listener(l *net.UDPConn, ctrl chan int, c chan []byte) {
 	}
 }
 
-func BuildListener(port uint16) (*net.UDPConn, chan int, chan []byte) {
+func BuildListener(port int) (*net.UDPConn, chan int, chan []byte) {
 	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", port))
 
 	if err != nil {


### PR DESCRIPTION
This makes it easier for people to use the package without needing to do any casting.

Fixes #16.
