### PR TITLE
add support for DogStatsD service check datagrams

### DIFF
--- a/async.go
+++ b/async.go
@@ -77,6 +77,16 @@ func (a *AsyncGodspeed) Send(stat, kind string, delta, sampleRate float64, tags 
 	a.Godspeed.Send(stat, kind, delta, sampleRate, tags)
 }
 
+// ServiceCheck is almost identical to that within the Godspeed client
+// with the addition of an argument and removal of the return value
+func (a *AsyncGodspeed) ServiceCheck(name string, status int, fields map[string]string, tags []string, y *sync.WaitGroup) {
+	if y != nil {
+		defer y.Done()
+	}
+
+	a.Godspeed.ServiceCheck(name, status, fields, tags)
+}
+
 // Count is almost identical to that within the Godspeed client
 // As with the other AsyncGodpseed functions it omits a return value and
 // takes a *sync.WaitGroup instance

--- a/async_test.go
+++ b/async_test.go
@@ -142,6 +142,20 @@ func (t *ATestSuite) TestAsyncSend(c *C) {
 	c.Check(string(a), Equals, string(b))
 }
 
+func (t *ATestSuite) TestAsyncServiceCheck(c *C) {
+	fields := make(map[string]string)
+	fields["service_check_message"] = "server on fire"
+	fields["timestamp"] = "1431484263"
+	fields["hostname"] = "brainbox01"
+
+	t.g.W.Add(1)
+	go t.g.ServiceCheck("testSvc", 0, fields, []string{"tag:test", "tag2:testing"}, t.g.W)
+
+	dgram, ok := <-t.o
+	c.Assert(ok, Equals, true)
+	c.Check(string(dgram), Equals, "_sc|testSvc|0|m:server on fire|d:1431484263|h:brainbox01|#test0,test1,tag:test,tag2:testing")
+}
+
 func (t *ATestSuite) TestAsyncCount(c *C) {
 	t.g.W.Add(1)
 	go t.g.Count("test.count", 1, extraTestTags, t.g.W)

--- a/godspeed.go
+++ b/godspeed.go
@@ -24,8 +24,7 @@ const (
 	DefaultPort = 8125
 
 	// MaxBytes is the largest UDP datagram we will try to send
-	// this is 8192 bytes minus the size of a UDP header
-	MaxBytes = 8192 - 8
+	MaxBytes = 8192
 )
 
 // Godspeed is an unbuffered Statsd client with compatability geared towards the Datadog statsd format

--- a/service_checks.go
+++ b/service_checks.go
@@ -1,0 +1,67 @@
+// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package godspeed
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+var scKeys = []string{"service_check_message", "timestamp", "hostname"}
+var scMark = []string{"m", "d", "h"}
+
+// ServiceCheck is a function to emit DogStatsD service checks
+// to the local DD agent. It takes the name of the service,
+// which must NOT contain a pipe (|) character, and the numeric
+// status for the service. The status values are the same as Nagios:
+//
+// OK = 0, WARNING = 1, CRITICAL = 2, UNKNOWN = 3
+//
+// This functionality is an extension to the statsd
+// protocol by Datadog (DogStatsD):
+//
+// http://docs.datadoghq.com/guides/dogstatsd/#service-checks
+func (g *Godspeed) ServiceCheck(name string, status int, fields map[string]string, tags []string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("service name must have at least one character")
+	}
+
+	if status < 0 || status > 3 {
+		return fmt.Errorf("unknown service status (%d); known values: 0,1,2,3", status)
+	}
+
+	if strings.ContainsAny("|", name) {
+		return fmt.Errorf("service name '%s' may not include pipe character ('|')", name)
+	}
+
+	var buf bytes.Buffer
+
+	buf.WriteString(fmt.Sprintf("_sc|%s|%d", name, status))
+
+	if len(fields) > 0 {
+		for i, v := range scKeys {
+			if mv, ok := fields[v]; ok {
+				buf.WriteString(fmt.Sprintf("|%s:%s", scMark[i], removePipes(mv)))
+			}
+		}
+	}
+
+	tags = uniqueTags(append(g.Tags, tags...))
+
+	if len(tags) > 0 {
+		for i, v := range tags {
+			tags[i] = strings.Replace(v, "|", "", -1)
+		}
+		buf.WriteString(fmt.Sprintf("|#%s", strings.Join(tags, ",")))
+	}
+
+	if bufLen := buf.Len(); bufLen > MaxBytes {
+		return fmt.Errorf("error sending %s service check, packet larger than %d (%d)", name, MaxBytes, bufLen)
+	}
+
+	_, err := g.Conn.Write(buf.Bytes())
+	return err
+}

--- a/service_checks_example_test.go
+++ b/service_checks_example_test.go
@@ -1,0 +1,36 @@
+// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package godspeed_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/PagerDuty/godspeed"
+)
+
+func ExampleGodspeed_ServiceCheck() {
+	// check the error
+	g, _ := godspeed.NewDefault()
+
+	defer g.Conn.Close()
+
+	service := "Nagios Service"
+	status := 0 // OK
+
+	// if you don't want these, pass nil to the function instead
+	optionals := make(map[string]string)
+	optionals["service_check_message"] = "down"
+	optionals["timestamp"] = "1431484263"
+
+	// if you don't want these, pass nil to the function instead
+	tags := []string{"some:tag"}
+
+	err := g.ServiceCheck(service, status, optionals, tags)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+	}
+}

--- a/service_checks_test.go
+++ b/service_checks_test.go
@@ -1,0 +1,114 @@
+// Copyright 2014-2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package godspeed_test
+
+import (
+	"fmt"
+
+	"github.com/PagerDuty/godspeed"
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) TestServiceCheck(c *C) {
+	//
+	// Test that a proper datagram is formed with
+	// with no fields or tags included
+	//
+	err := t.g.ServiceCheck("testSvc", 0, nil, nil)
+	c.Assert(err, IsNil)
+
+	dgram, ok := <-t.o
+	c.Assert(ok, Equals, true)
+	c.Check(string(dgram), Equals, "_sc|testSvc|0")
+
+	//
+	// Test that the datagram is valid with tags
+	//
+	err = t.g.ServiceCheck("testSvc", 1, nil, []string{"tag:test", "tag2:testing"})
+	c.Assert(err, IsNil)
+
+	dgram, ok = <-t.o
+	c.Assert(ok, Equals, true)
+	c.Check(string(dgram), Equals, "_sc|testSvc|1|#tag:test,tag2:testing")
+
+	//
+	// Test that the datagram is valid with the
+	// service_check_message field
+	//
+	fields := make(map[string]string)
+	fields["service_check_message"] = "server on fire"
+
+	err = t.g.ServiceCheck("testSvc", 1, fields, nil)
+	c.Assert(err, IsNil)
+
+	dgram, ok = <-t.o
+	c.Assert(ok, Equals, true)
+	c.Check(string(dgram), Equals, "_sc|testSvc|1|m:server on fire")
+
+	//
+	// Test that the datagram is valid with the timestamp field
+	//
+	fields["timestamp"] = "1431484263"
+
+	err = t.g.ServiceCheck("testSvc", 1, fields, nil)
+	c.Assert(err, IsNil)
+
+	dgram, ok = <-t.o
+	c.Assert(ok, Equals, true)
+	c.Check(string(dgram), Equals, "_sc|testSvc|1|m:server on fire|d:1431484263")
+
+	//
+	// Test that the datagram is valid with the hostname field
+	//
+	fields["hostname"] = "brainbox01"
+
+	err = t.g.ServiceCheck("testSvc", 2, fields, nil)
+	c.Assert(err, IsNil)
+
+	dgram, ok = <-t.o
+	c.Assert(ok, Equals, true)
+	c.Check(string(dgram), Equals, "_sc|testSvc|2|m:server on fire|d:1431484263|h:brainbox01")
+
+	//
+	// Test that the datagram is valid when we put it all together
+	//
+	err = t.g.ServiceCheck("testSvc", 3, fields, []string{"tag:test", "tag2:testing"})
+	c.Assert(err, IsNil)
+
+	dgram, ok = <-t.o
+	c.Assert(ok, Equals, true)
+	c.Check(string(dgram), Equals, "_sc|testSvc|3|m:server on fire|d:1431484263|h:brainbox01|#tag:test,tag2:testing")
+
+	//
+	// Test that invalid service names trigger an error
+	//
+	err = t.g.ServiceCheck("", 0, nil, nil)
+	c.Assert(err, Not(IsNil))
+	c.Check(err.Error(), Equals, "service name must have at least one character")
+
+	err = t.g.ServiceCheck("some|pipe", 0, nil, nil)
+	c.Assert(err, Not(IsNil))
+	c.Check(err.Error(), Equals, "service name 'some|pipe' may not include pipe character ('|')")
+
+	//
+	// Test that invalid service statuses trigger an error
+	//
+	err = t.g.ServiceCheck("testSvc", 4, nil, nil)
+	c.Assert(err, Not(IsNil))
+	c.Check(err.Error(), Equals, "unknown service status (4); known values: 0,1,2,3")
+
+	err = t.g.ServiceCheck("testSvc", -1, nil, nil)
+	c.Assert(err, Not(IsNil))
+	c.Check(err.Error(), Equals, "unknown service status (-1); known values: 0,1,2,3")
+
+	//
+	// Test that making the datagram huge causes a failure
+	//
+	svcTitle := randString(godspeed.MaxBytes)
+
+	err = t.g.ServiceCheck(svcTitle, 0, nil, nil)
+	c.Assert(err, Not(IsNil))
+	c.Check(err.Error(), Equals, fmt.Sprintf("error sending %s service check, packet larger than 8192 (8198)", svcTitle))
+}


### PR DESCRIPTION
This change adds support for the DogStatsD Service Checks datagram:
- http://docs.datadoghq.com/guides/dogstatsd/#service-checks

This is done with the `ServiceCheck()` function on both `*Godspeed` and `*AsyncGodspeed`.

In addition, the `MaxBytes` value was made 8192 bytes and the `Event()` function had some logic improvements.
