### PR TITLE
bump test golang version to 1.5.1; add 1.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-  - 1.5
+  - 1.4.2
+  - 1.5.1
 branches:
   only:
     - master

--- a/async_test.go
+++ b/async_test.go
@@ -43,6 +43,7 @@ func (t *ATestSuite) TearDownTest(c *C) {
 	t.l.Close()
 	close(t.c)
 	t.g.Godspeed.Conn.Close()
+	time.Sleep(time.Millisecond * 10)
 }
 
 func testAsyncBasicFunc(t *ATestSuite, c *C, g *godspeed.AsyncGodspeed) {

--- a/godspeed_test.go
+++ b/godspeed_test.go
@@ -7,6 +7,7 @@ package godspeed_test
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/PagerDuty/godspeed"
 	"github.com/PagerDuty/godspeed/gspdtest"
@@ -41,6 +42,7 @@ func (t *TestSuite) TearDownTest(c *C) {
 	t.l.Close()
 	close(t.c)
 	t.g.Conn.Close()
+	time.Sleep(time.Millisecond * 10)
 }
 
 func testBasicFunc(t *TestSuite, c *C, g *godspeed.Godspeed) {


### PR DESCRIPTION
We should test Godspeed against the most current version of go (`v1.5.1`). However, since this is being consumed by others in the community it may make sense to also test the latest version of the last go release (in this case `v1.4.2`).
