### PR TITLE
only test against Go 1.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-  - 1.4.2
-  - 1.5.1
+  - 1.5.3
 branches:
   only:
     - master


### PR DESCRIPTION
There was a security vulnerability patched in Go `1.5.3`, so let's get our test version of Go up to that.

Also, seems like `1.4.x` is EOL so no use continuing to build against it.
