### PR TITLE
fix typo in comment and add comment to gspdtest

### DIFF
--- a/godspeed.go
+++ b/godspeed.go
@@ -31,7 +31,7 @@ const (
 	MaxBytes = 8192
 )
 
-// Godspeed is an unbuffered Statsd client with compatability geared towards the Datadog statsd format
+// Godspeed is an unbuffered Statsd client with compatibility geared towards the Datadog statsd format
 // It consists of Conn (*net.UDPConn) object for sending metrics over UDP,
 // Namespace (string) for namespacing metrics, and Tags ([]string) for tags to send with stats
 type Godspeed struct {

--- a/gspdtest/gspdtest.go
+++ b/gspdtest/gspdtest.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
+// Package gspdtest is a package used by Godspeed for testing. This package
+// isn't really meant to be consumed by anyone.
 package gspdtest
 
 import (
@@ -10,6 +12,9 @@ import (
 	"net"
 )
 
+// Listener is a function which takes a *net.UDPConn and sends any data received
+// on it back over the c channel. This function is meant to be ran within a
+// goroutine. The ctrl channel is used to shut down the goroutine.
 func Listener(l *net.UDPConn, ctrl chan int, c chan []byte) {
 	for {
 		select {
@@ -32,6 +37,8 @@ func Listener(l *net.UDPConn, ctrl chan int, c chan []byte) {
 	}
 }
 
+// BuildListener is a function which builds a *net.UDPConn listening on localhost
+// on the port specified. It also returns a control channel and a return channel.
 func BuildListener(port int) (*net.UDPConn, chan int, chan []byte) {
 	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", port))
 


### PR DESCRIPTION
This fixes a typo in the comment of the Godspeed struct. In addition, it adds comments to the `gspdtest` public functions even with the package not meaning to be used publicly.
