### PR TITLE
Reduce Send allocations

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -7,8 +7,10 @@ package godspeed
 import "strings"
 
 // stats names can't include :, |, or @
+var reservedReplacer = strings.NewReplacer(":", "_", "|", "_", "@", "_")
+
 func trimReserved(s string) string {
-	return strings.NewReplacer(":", "_", "|", "_", "@", "_").Replace(s)
+	return reservedReplacer.Replace(s)
 }
 
 // function to make sure tags are unique

--- a/stats.go
+++ b/stats.go
@@ -31,24 +31,28 @@ func (g *Godspeed) Send(stat, kind string, delta, sampleRate float64, tags []str
 
 	// if we have a namespace write it to the byte buffer
 	if len(g.Namespace) > 0 {
-		buffer.WriteString(fmt.Sprintf("%v.", g.Namespace))
+		buffer.WriteString(g.Namespace)
+		buffer.WriteByte('.')
 	}
 
-	floatStr := strconv.FormatFloat(delta, 'f', -1, 64)
-
 	// write the name of the metric to the byte buffer as well as the metric itself
-	buffer.WriteString(fmt.Sprintf("%v:%v|%v", string(trimReserved(stat)), floatStr, kind))
+	buffer.WriteString(trimReserved(stat))
+	buffer.WriteByte(':')
+	buffer.WriteString(strconv.FormatFloat(delta, 'f', -1, 64))
+	buffer.WriteByte('|')
+	buffer.WriteString(kind)
 
 	// if the sample rate is less than 1 add it too
 	if sampleRate < 1 {
-		floatStr = strconv.FormatFloat(sampleRate, 'f', -1, 64)
-		buffer.WriteString(fmt.Sprintf("|@%v", floatStr))
+		buffer.WriteString("|@")
+		buffer.WriteString(strconv.FormatFloat(sampleRate, 'f', -1, 64))
 	}
 
 	// add any provided tags to the metric
 	tags = uniqueTags(append(g.Tags, tags...))
 	if len(tags) > 0 {
-		buffer.WriteString(fmt.Sprintf("|#%v", strings.Join(tags, ",")))
+		buffer.WriteString("|#")
+		buffer.WriteString(strings.Join(tags, ","))
 	}
 
 	// this handles the logic for truncation

--- a/stats_test.go
+++ b/stats_test.go
@@ -219,3 +219,17 @@ func (t *TestSuite) TestSet(c *C) {
 	c.Assert(ok, Equals, true)
 	c.Check(string(a), Equals, "test.set:10|s")
 }
+
+func (t *TestSuite) BenchmarkIncr(c *C) {
+	t.g.SetNamespace("namespace")
+	t.g.AddTags([]string{"a:1111", "b:2"})
+	err := t.g.Incr("bench.incr", []string{"c:333", "d:444", "e:555555555"})
+	c.Assert(err, IsNil)
+
+	a, ok := <-t.o
+	c.Assert(ok, Equals, true)
+	c.Check(string(a), Equals, "namespace.bench.incr:1|c|#a:1111,b:2,c:333,d:444,e:555555555")
+	for i := 0; i < c.N; i++ {
+		t.g.Incr("bench.incr", []string{"c:333", "d:444", "e:555555555"})
+	}
+}


### PR DESCRIPTION
```
benchmark           old ns/op     new ns/op     delta
BenchmarkIncr-8     5955          3808          -36.05%

benchmark           old allocs     new allocs     delta
BenchmarkIncr-8     18             8              -55.56%

benchmark           old bytes     new bytes     delta
BenchmarkIncr-8     976           577           -40.88%
```