### PR TITLE
Performance improvements to events, stats and service_checks

### DIFF
--- a/events.go
+++ b/events.go
@@ -65,7 +65,7 @@ func (g *Godspeed) Event(title, text string, fields map[string]string, tags []st
 		}
 	}
 
-	tags = uniqueTags(append([]string{}, append(g.Tags, tags...)...))
+	tags = uniqueTags(g.Tags, tags)
 	if len(tags) > 0 {
 		for i, v := range tags {
 			tags[i] = removePipes(v)

--- a/events.go
+++ b/events.go
@@ -13,12 +13,15 @@ import (
 var eventKeys = []string{"date_happened", "hostname", "aggregation_key", "priority", "source_type_name", "alert_type"}
 var eventMarkers = []rune{'d', 'h', 'k', 'p', 's', 't'}
 
+var escapeEventReplacer = strings.NewReplacer("\n", "\\n")
+var pipesReplacer = strings.NewReplacer("|", "")
+
 func escapeEvent(s string) string {
-	return strings.NewReplacer("\n", "\\n").Replace(s)
+	return escapeEventReplacer.Replace(s)
 }
 
 func removePipes(s string) string {
-	return strings.Replace(s, "|", "", -1)
+	return pipesReplacer.Replace(s)
 }
 
 // Event is the function for submitting a Datadog event.
@@ -55,7 +58,7 @@ func (g *Godspeed) Event(title, text string, fields map[string]string, tags []st
 
 	if len(tags) > 0 {
 		for i, v := range tags {
-			tags[i] = strings.Replace(v, "|", "", -1)
+			tags[i] = removePipes(v)
 		}
 
 		buf.WriteString(fmt.Sprintf("|#%v", strings.Join(tags, ",")))

--- a/events_test.go
+++ b/events_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	// this is *C comes from
+	"github.com/PagerDuty/godspeed"
 	. "gopkg.in/check.v1"
 )
 
@@ -183,4 +184,25 @@ func (t *TestSuite) TestEvent(c *C) {
 	a, ok = <-t.o
 	c.Assert(ok, Equals, true)
 	c.Check(string(a), Equals, "_e{1,1}:j|k|#test0,test1,test8,test9")
+}
+
+func (t *TestSuite) BenchmarkEvents(c *C) {
+	g, _ := godspeed.NewDefault()
+
+	defer g.Conn.Close()
+
+	title := "Nginx service restart"
+	text := "The Nginx service has been restarted"
+
+	// the optionals are for the optional arguments available for an event
+	// http://docs.datadoghq.com/guides/dogstatsd/#fields
+	optionals := make(map[string]string)
+	optionals["alert_type"] = "info"
+	optionals["source_type_name"] = "nginx"
+
+	addlTags := []string{"source_type:nginx"}
+
+	for i := 0; i < c.N; i++ {
+		g.Event(title, text, optionals, addlTags)
+	}
 }

--- a/godspeed.go
+++ b/godspeed.go
@@ -114,7 +114,7 @@ func (g *Godspeed) AddTags(tags []string) []string {
 			g.AddTag(tag)
 		}
 	} else {
-		g.Tags = uniqueTags(tags)
+		g.Tags = uniqueTags(nil, tags)
 	}
 
 	return g.Tags

--- a/service_checks.go
+++ b/service_checks.go
@@ -56,7 +56,7 @@ func (g *Godspeed) ServiceCheck(name string, status int, fields map[string]strin
 		}
 	}
 
-	tags = uniqueTags(append([]string{}, append(g.Tags, tags...)...))
+	tags = uniqueTags(g.Tags, tags)
 
 	if len(tags) > 0 {
 		for i, v := range tags {

--- a/shared.go
+++ b/shared.go
@@ -14,7 +14,12 @@ func trimReserved(s string) string {
 }
 
 // function to make sure tags are unique
-func uniqueTags(t []string) []string {
+func uniqueTags(gt, t []string) []string {
+	allTags := make([]string, 0, len(gt)+len(t))
+	allTags = append(allTags, gt...)
+	allTags = append(allTags, t...)
+	t = allTags
+
 	// if the tag slice is empty avoid allocation
 	if len(t) < 1 {
 		return nil

--- a/stats.go
+++ b/stats.go
@@ -49,7 +49,7 @@ func (g *Godspeed) Send(stat, kind string, delta, sampleRate float64, tags []str
 	}
 
 	// add any provided tags to the metric
-	tags = uniqueTags(append(tags, g.Tags...))
+	tags = uniqueTags(append([]string{}, append(g.Tags, tags...)...))
 	if len(tags) > 0 {
 		buffer.WriteString("|#")
 		buffer.WriteString(strings.Join(tags, ","))

--- a/stats.go
+++ b/stats.go
@@ -36,7 +36,7 @@ func (g *Godspeed) Send(stat, kind string, delta, sampleRate float64, tags []str
 	}
 
 	// write the name of the metric to the byte buffer as well as the metric itself
-	buffer.WriteString(trimReserved(stat))
+	reservedReplacer.WriteString(&buffer, stat)
 	buffer.WriteByte(':')
 	buffer.WriteString(strconv.FormatFloat(delta, 'f', -1, 64))
 	buffer.WriteByte('|')

--- a/stats.go
+++ b/stats.go
@@ -49,7 +49,7 @@ func (g *Godspeed) Send(stat, kind string, delta, sampleRate float64, tags []str
 	}
 
 	// add any provided tags to the metric
-	tags = uniqueTags(append([]string{}, append(g.Tags, tags...)...))
+	tags = uniqueTags(g.Tags, tags)
 	if len(tags) > 0 {
 		buffer.WriteString("|#")
 		buffer.WriteString(strings.Join(tags, ","))

--- a/stats.go
+++ b/stats.go
@@ -49,7 +49,7 @@ func (g *Godspeed) Send(stat, kind string, delta, sampleRate float64, tags []str
 	}
 
 	// add any provided tags to the metric
-	tags = uniqueTags(append(g.Tags, tags...))
+	tags = uniqueTags(append(tags, g.Tags...))
 	if len(tags) > 0 {
 		buffer.WriteString("|#")
 		buffer.WriteString(strings.Join(tags, ","))
@@ -72,37 +72,37 @@ func (g *Godspeed) Send(stat, kind string, delta, sampleRate float64, tags []str
 
 // Count wraps Send() and simplifies the interface for Count stats
 func (g *Godspeed) Count(stat string, count float64, tags []string) error {
-	return g.Send(stat, "c", count, 1, append(g.Tags, tags...))
+	return g.Send(stat, "c", count, 1, tags)
 }
 
 // Incr wraps Send() and simplifies the interface for incrementing a counter
 // It only takes the name of the stat, and tags
 func (g *Godspeed) Incr(stat string, tags []string) error {
-	return g.Count(stat, 1, append(g.Tags, tags...))
+	return g.Count(stat, 1, tags)
 }
 
 // Decr wraps Send() and simplifies the interface for decrementing a counter
 // It only takes the name of the stat, and tags
 func (g *Godspeed) Decr(stat string, tags []string) error {
-	return g.Count(stat, -1, append(g.Tags, tags...))
+	return g.Count(stat, -1, tags)
 }
 
 // Gauge wraps Send() and simplifies the interface for Gauge stats
 func (g *Godspeed) Gauge(stat string, value float64, tags []string) error {
-	return g.Send(stat, "g", value, 1, append(g.Tags, tags...))
+	return g.Send(stat, "g", value, 1, tags)
 }
 
 // Histogram wraps Send() and simplifies the interface for Histogram stats
 func (g *Godspeed) Histogram(stat string, value float64, tags []string) error {
-	return g.Send(stat, "h", value, 1, append(g.Tags, tags...))
+	return g.Send(stat, "h", value, 1, tags)
 }
 
 // Timing wraps Send() and simplifies the interface for Timing stats
 func (g *Godspeed) Timing(stat string, value float64, tags []string) error {
-	return g.Send(stat, "ms", value, 1, append(g.Tags, tags...))
+	return g.Send(stat, "ms", value, 1, tags)
 }
 
 // Set wraps Send() and simplifies the interface for Timing stats
 func (g *Godspeed) Set(stat string, value float64, tags []string) error {
-	return g.Send(stat, "s", value, 1, append(g.Tags, tags...))
+	return g.Send(stat, "s", value, 1, tags)
 }


### PR DESCRIPTION
This PR reduces allocations made in events, stats and service_checks. Benchmarks show a significant improvement in ns/op and reduction of allocs/op.

There was also the risk of append modifying g.Tags everywhere (since append can change the slice underneath), this was mitigated by appending to an intermediate array (no additional allocations since it starts off as an empty slice with enough space for all tags).

Note: This could be further optimised by not creating additional intermediate arrays (it can be directly written to stream) and avoiding strings.Join (these can be directly written to stream as well).

New:-
```
13:19:41 DeepakMacbook: > go test -check.b -check.bmem
PASS: events_test.go:189: TestSuite.BenchmarkEvents	  500000	      5566 ns/op	     304 B/op	       3 allocs/op
PASS: stats_test.go:223: TestSuite.BenchmarkIncr	  500000	      5504 ns/op	     336 B/op	       7 allocs/op
OK: 2 passed
PASS
ok  	github.com/redsift/hilt/vendor/github.com/PagerDuty/godspeed	5.788s
```

Old:-
```
13:22:45 DeepakMacbook: > go test -check.b -check.bmem
PASS: events_test.go:189: TestSuite.BenchmarkEvents	  200000	     11714 ns/op	   12962 B/op	      25 allocs/op
PASS: stats_test.go:223: TestSuite.BenchmarkIncr	  200000	      6693 ns/op	     577 B/op	       8 allocs/op
OK: 2 passed
PASS
ok  	github.com/PagerDuty/godspeed	4.009s
```
