### PR TITLE
Deprecation Notice: point users to the theckman/godspeed fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 [![GoDoc](https://img.shields.io/badge/godspeed-GoDoc-blue.svg?style=flat)](https://godoc.org/github.com/PagerDuty/godspeed)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-brightgreen.svg?style=flat)](https://github.com/PagerDuty/godspeed/blob/master/LICENSE)
 
+### Deprecation Notice
+This repository is deprecated. No further Issues or Pull Requests will be considered or approved.
+
+Further interest should be directed to the new `godspeed` repository. If you'd like to check out the latest version of the source code, report any issues, contribute any improvements, or download the latest release, please do so at:
+
+* https://github.com/theckman/godspeed
+
+## Overview
+
 Godspeed is a statsd client for the Datadog extension of statsd (DogStatsD).
 The name `godspeed` is a bit of a rhyming slang twist on DogStatsD. It's also a
 poke at the fact that the statsd protocol's transport mechanism is UDP...


### PR DESCRIPTION
While working at PagerDuty I open sourced `godspeed`, which is one of my first
Go projects as well as one of my first open source projects in general. This
makes it a special project to me personally.

I understand that it takes quite a bit of time, and passion, to maintain
software that is open sourced. It seems that those who had an interest in
maintaining `godspeed` have since moved-on from PagerDuty, so I am asking that
my fork of `godspeed` become the canonical repository.

I've previously taken over another GitHub repository (`pagerduty/cronner`), and
a similar change was made there too:

- https://github.com/PagerDuty/cronner/pull/55

Because `cronner` depends on `godspeed`, I have an interest in making sure that
the `godspeed` repository stays well-maintained.

Please merge this change at your earliest convenience.

Signed-off-by: Tim Heckman <t@heckman.io>

/cc @azacharyallen @andrecloutier-pd @richadams @esigler 